### PR TITLE
Compatibility/20220308_v106 [pom] shading guava and pb to avoid jar confilct

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,60 @@
 
   <build>
       <plugins>
+               <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <!--                <version>3.0.0</version>-->
+                <version>3.2.1</version>
+                <executions>
+                    <!-- Run shade goal on package phase -->
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.apache.flink:force-shading</exclude>
+                                    <exclude>com.google.code.findbugs:jsr305</exclude>
+                                    <exclude>org.slf4j:*</exclude>
+                                    <exclude>log4j:*</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <!-- Do not copy the sigsnatures in the META-INF folder.
+                                    Otherwise, this might cause SecurityExceptions when using the JAR. -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                             
+                               <relocation>
+                                    <pattern>com.google.guava</pattern>
+                                    <shadedPattern>org.shaded.tencent.ieg.guava</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.protobuf</pattern>
+                                    <shadedPattern>org.shaded.tencent.ieg.protobuf</shadedPattern>
+                                </relocation>
+                            </relocations>
+                    
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml
+                    </dependencyReducedPomLocation>
+                </configuration>
+            </plugin>
         <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>nexus-staging-maven-plugin</artifactId>


### PR DESCRIPTION
### purpose of the change
    avoid guava jar conflict with platforms preloading with the ones in different version
### what part does this pull request potentially affect ?
      none changes to the code but the pom file : adding this very relocation to it would do the trick 
      and fix guava conflict once for all : 

![image](https://user-images.githubusercontent.com/45913164/162138624-ecdeff99-8d18-4284-bb11-07bbb9ee8967.png)
