### PR TITLE
Compatibility/[pom] shading guava , pb and log4j to avoid jar confilct

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,14 +96,20 @@
                                 </filter>
                             </filters>
                             <relocations>
-                               <relocation>
-                                    <pattern>com.google.guava</pattern>
-                                    <shadedPattern>org.shaded.tencent.ieg.guava</shadedPattern>
+                           <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>shaded.com.tencent.cls.google</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>org.slf4j</pattern>
+                                    <shadedPattern>shaded.org.tencent.cls.slf4j</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>com.google.protobuf</pattern>
-                                    <shadedPattern>org.shaded.tencent.ieg.protobuf</shadedPattern>
+                                    <pattern>ch.qos</pattern>
+                                    <shadedPattern>shaded.tencent.cls.ch.qos</shadedPattern>
                                 </relocation>
+                              
                             </relocations>
                             <transformers>
                                 <transformer


### PR DESCRIPTION
**### purpose of the change**

         avoid guava , pb and log4j jar conflict with platforms preloading with the ones in different version

**### what part does this pull request potentially affect ?**

         none change to the code but the pom file : adding this very relocation to it would do the trick 
  and fix conflict once for all